### PR TITLE
[FINAL] Fix problem when calculating checksum in platforms with different architectures

### DIFF
--- a/MSEmojiChecksumCalculator.m
+++ b/MSEmojiChecksumCalculator.m
@@ -45,7 +45,7 @@ static NSString * const MSAllEmojiCharacterString =  @"😃😀😊☺😉😍�
         if (((i + 1) % EMOJI_CHECKSUM_LENGTH) == 0)
         {
             // make a char
-            NSUInteger idx = byte % [MSAllEmojiCharacterString length];
+            NSUInteger idx = byte % (unsigned int)[MSAllEmojiCharacterString length];
             NSRange emojiRange = [MSAllEmojiCharacterString rangeOfComposedCharacterSequenceAtIndex:idx];
             [emojiChecksum appendString:[MSAllEmojiCharacterString substringWithRange:emojiRange]];
             byte = 0;

--- a/MSEmojiChecksumCalculator.m
+++ b/MSEmojiChecksumCalculator.m
@@ -45,7 +45,7 @@ static NSString * const MSAllEmojiCharacterString =  @"😃😀😊☺😉😍�
         if (((i + 1) % EMOJI_CHECKSUM_LENGTH) == 0)
         {
             // make a char
-            NSUInteger idx = byte % (unsigned int)[MSAllEmojiCharacterString length];
+            NSUInteger idx = byte % (uint32_t)[MSAllEmojiCharacterString length];
             NSRange emojiRange = [MSAllEmojiCharacterString rangeOfComposedCharacterSequenceAtIndex:idx];
             [emojiChecksum appendString:[MSAllEmojiCharacterString substringWithRange:emojiRange]];
             byte = 0;


### PR DESCRIPTION
If we try to get the checksum in platforms with different architectures we got different results. 

With this we convert the result to 32-bit so the checksum is the same in both 32 and 64-bit architectures.
